### PR TITLE
Fix log file naming consistency and archive service reliability

### DIFF
--- a/src/services/file_processing_service.py
+++ b/src/services/file_processing_service.py
@@ -302,13 +302,16 @@ class FileProcessingService:
             # Get log file name using the same logic as logging service
             log_file_name = None
             if self.run_start_time:
-                # Clean the filename for use in log filename (same logic as logging_service.py)
-                clean_filename = "".join(
-                    c for c in filename if c.isalnum() or c in (" ", "-", "_")
-                ).rstrip()
-                clean_filename = clean_filename.replace(" ", "_")
+                # Use the original filename for log filename (same logic as logging_service.py)
+                # First, extract just the filename without path (same as logging_service.py)
+                import os
+
+                base_filename = os.path.basename(filename)
+
+                # Use the original filename (just replace spaces with underscores for file system compatibility)
+                log_filename_base = base_filename.replace(" ", "_")
                 timestamp = self.run_start_time.strftime("%Y%m%d_%H%M%S")
-                log_file_name = f"{clean_filename}_{timestamp}.log"
+                log_file_name = f"{log_filename_base}_{timestamp}.log"
 
             self.database_service.update_file_processing_status(
                 file_name=filename,

--- a/src/services/logging_service.py
+++ b/src/services/logging_service.py
@@ -195,7 +195,7 @@ class LoggingService:
                 f"Log directory is writable: {os.access(log_dir, os.W_OK)}"
             )
 
-            # Clean the filename for use in log filename
+            # Use the original filename for log filename
             # First, extract just the filename without path
             import os
 
@@ -203,14 +203,11 @@ class LoggingService:
             base_filename = os.path.basename(processed_filename)
             self.logger.info(f"Extracted base_filename: '{base_filename}'")
 
-            # Then clean the filename
-            clean_filename = "".join(
-                c for c in base_filename if c.isalnum() or c in (" ", "-", "_")
-            ).rstrip()
-            clean_filename = clean_filename.replace(" ", "_")
-            self.logger.info(f"Cleaned filename: '{clean_filename}'")
+            # Use the original filename (just replace spaces with underscores for file system compatibility)
+            log_filename_base = base_filename.replace(" ", "_")
+            self.logger.info(f"Log filename base: '{log_filename_base}'")
             timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
-            log_filename = f"{clean_filename}_{timestamp}.log"
+            log_filename = f"{log_filename_base}_{timestamp}.log"
 
             log_file = log_dir / log_filename
             self.logger.info(f"Log file path: {log_file}")


### PR DESCRIPTION
- Fix log file naming: Use original filename instead of cleaned version
- Fix archive service: Add fallback to local archiving when COS unavailable
- Fix import paths: Update all imports to use src. prefix
- Ensure consistent log file names between database and actual files
- Ensure files are always archived regardless of environment